### PR TITLE
setup Scala serializer for the test harness

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.8.0

--- a/src/test/scala/org/example/MyProcessFunctionHarnessTest.scala
+++ b/src/test/scala/org/example/MyProcessFunctionHarnessTest.scala
@@ -1,9 +1,11 @@
 package org.example
 
+import org.apache.flink.api.common.serialization.SerializerConfigImpl
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.operators.ProcessOperator
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness
 import org.apache.flink.util.Collector
+import org.apache.flinkx.api.serializers._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -18,13 +20,16 @@ class MyProcessFunctionHarnessTest extends AnyFunSuite with Matchers {
   }
 
   test("Process element should output None") {
+    val serializer = deriveTypeInformation[Option[Int]].createSerializer(
+      new SerializerConfigImpl()
+    )
     val operator = new ProcessOperator(new MyProcessFunction)
     val harness = new OneInputStreamOperatorTestHarness(operator)
-    harness.setup()
+    harness.setup(serializer)
     try {
       harness.open()
       harness.processElement(1, 0L)
-      harness.getOutput.poll() should be(None)
+      harness.getRecordOutput.iterator().next().getValue should be(None)
     } finally {
       harness.close()
     }


### PR DESCRIPTION
- setup Scala serializer for Option
- use `getRecordOutput` because `getOutput` deserialises records incorrectly. 